### PR TITLE
Fixed setup.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ docs/_templates
 *.buildinfo
 *.doctree
 *.pickle
+build/
+*.egg-info
+tests/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 import re
 
 version = ""
@@ -16,25 +16,31 @@ requirements = []
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Operating System :: OS Independent",
+    "Topic :: Internet",
+    "Topic :: Utilities",
+]
+
+
 setup(
     name="PyTweet",
-    authors=["TheGenocide", "TheFarGG"],
+    author="TheGenocide & TheFarGG",
     url="https://github.com/TheFarGG/PyTweet/",
     version=version,
-    packages=find_packages(),
+    packages=["pytweet", "pytweet.types"],
+    include_package_data=True,
     license="MIT",
     description="A Synchronous python API wrapper for twitter's api",
     long_description=readme,
     long_description_content_type="text/markdown",
-    include_package_data=True,
     install_requires=requirements,
-    keywords=["PyTweet", "pytweet", "twitter", "tweet.py", "twitter.py"],
+    keywords="PyTweet, pytweet, twitter, tweet.py twitter.py",
     python_requires=">=3.7.0",
-    classifiers=[
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
+    classifiers=classifiers
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author="TheGenocide & TheFarGG",
     url="https://github.com/TheFarGG/PyTweet/",
     version=version,
-    packages=["pytweet", "pytweet.types"],
+    packages=["pytweet"],
     include_package_data=True,
     license="MIT",
     description="A Synchronous python API wrapper for twitter's api",


### PR DESCRIPTION
This pr fixes setup.py

# Things it fixed
- authors shouldn't be a list, there is no keyword called `authors` in setuptools.setup
- keywords shouldn't be a list, instead it should be like `abc, cba`
- classifiers, adding the `'Programming Language :: Python :: 3` means it supports any python 3 version (I think) so i removed it and added the ones we support, Including python 3.10 (I tested on 3.10)

# Things it adds/removes
- the `packages` list has `find_packages` which also sometimes includes other folders, i fixed this by doing 
```py
packages=["pytweet", "pytweet.types"]
```

I tested all these changes.
